### PR TITLE
Fix a bug with image loading for 'norewind' calls.

### DIFF
--- a/src/js/justifiedGallery.js
+++ b/src/js/justifiedGallery.js
@@ -173,7 +173,7 @@
       }
 
       if ($image.data('jg.loaded') === 'skipped') {
-        $image.one('load', function() {
+        onImageEvent(imageSrc, function() {
           showImg($entry, loadNewImage, context);
           $image.data('jg.loaded', true);
         });
@@ -527,6 +527,30 @@
 
     }
 
+    function onImageEvent(imageSrc, onLoad, onError) {
+      if (!onLoad && !onError) {
+        return;
+      }
+      /* Check if the image is loaded or not using another image object.
+       We cannot use the 'complete' image property, because some browsers,
+       with a 404 set complete = true */
+      var memImage = new Image();
+      var $memImage = $(memImage);
+      if (onLoad) {
+        $memImage.one('load', function () {
+          $memImage.off('load error');
+          onLoad(memImage);
+        });
+      }
+      if (onError) {
+        $memImage.one('error', function() {
+          $memImage.off('load error');
+          onError(memImage);
+        });
+      }
+      memImage.src = imageSrc;
+    }
+
     return this.each(function (index, gallery) {
 
       var $gallery = $(gallery);
@@ -643,26 +667,18 @@
             startLoadingSpinnerAnimation(context.spinner);
           }
 
-          /* Check if the image is loaded or not using another image object.
-            We cannot use the 'complete' image property, because some browsers, 
-            with a 404 set complete = true */
-          var loadImg = new Image();
-          var $loadImg = $(loadImg);
-          $loadImg.one('load', function imgLoaded () {
+          onImageEvent(imageSrc, function imgLoaded (loadImg) {
             //DEBUG// console.log('img load (alt: ' + $image.attr('alt') + ')');
-            $image.off('load error');
             $image.data('jg.imgw', loadImg.width);
             $image.data('jg.imgh', loadImg.height);
             $image.data('jg.loaded', true);
             startImgAnalyzer(context, false);
-          });
-          $loadImg.one('error', function imgLoadError () {
+          }, function imgLoadError () {
             //DEBUG// console.log('img error (alt: ' + $image.attr('alt') + ')');
             $image.off('load error');
             $image.data('jg.loaded', 'error');
             startImgAnalyzer(context, false);
           });
-          loadImg.src = imageSrc;
 
         }
 

--- a/src/js/justifiedGallery.js
+++ b/src/js/justifiedGallery.js
@@ -675,7 +675,6 @@
             startImgAnalyzer(context, false);
           }, function imgLoadError () {
             //DEBUG// console.log('img error (alt: ' + $image.attr('alt') + ')');
-            $image.off('load error');
             $image.data('jg.loaded', 'error');
             startImgAnalyzer(context, false);
           });

--- a/test/main/norewind_loaded_images.html
+++ b/test/main/norewind_loaded_images.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<script src='../../libs/jquery/jquery.min.js'></script>
+	<link rel='stylesheet' href='../../dist/css/justifiedGallery.css' type='text/css' media='all' />
+	<script src='../../src/js/justifiedGallery.js'></script>
+	<script>
+
+		$(document).ready(function () {
+			var $gallery = $("#gallery");
+			// capture elements to add later, these are just a clone of the current elements
+			var toAdd = $gallery[0].innerHTML;
+			$gallery.justifiedGallery({
+				waitThumbnailsLoad: false
+			});
+
+			// add more images that we know have already loaded
+			$gallery.append(toAdd);
+			// give the images a chance to load before we update the gallery
+			setTimeout(function () {
+				$gallery.justifiedGallery('norewind');
+			}, 0);
+		});
+	</script>
+</head>
+<body>
+<h1>NoRewind with loaded image test</h1>
+
+<p>This test check whether the infinite scroll behaviour works when images are already loaded.</p>
+
+<p>If the test passes you should see every image twice, the first image is a bw food counter and the last image is of
+	a heart necklace. If the test fails the second set of pictures will not show up, though they are still there and can
+	be clicked on.</p>
+
+<div id="gallery">
+	<a href="../photos/8083451788_552becfbc7_b.jpg" title="What's your destination?">
+		<img alt="What's your destination?" src="../photos/8083451788_552becfbc7_m.jpg" width="240" height="198" />
+	</a>
+	<a href="../photos/7948632554_01f6ae6b6f_b.jpg" title="Just in a dream Place">
+		<img alt="Just in a dream Place" src="../photos/7948632554_01f6ae6b6f_m.jpg" width="240" height="160" />
+	</a>
+	<a href="../photos/7302459122_19fa1d8223_b.jpg" title="Truthful Innocence">
+		<img alt="Truthful Innocence" src="../photos/7302459122_19fa1d8223_m.jpg" width="240" height="160" />
+	</a>
+	<a href="../photos/7222046648_5bf70e893a_b.jpg" title="Simply my Brother">
+		<img alt="Simply my Brother" src="../photos/7222046648_5bf70e893a_m.jpg" width="240" height="125" />
+	</a>
+	<a href="../photos/7002395006_29fdc85f7a_b.jpg" title="Freedom">
+		<img alt="Freedom" src="../photos/7002395006_29fdc85f7a_m.jpg" width="240" height="132" />
+	</a>
+	<a href="../photos/7062575651_b23918b11a_b.jpg" title="Maybe spring">
+		<img alt="Maybe spring" src="../photos/7062575651_b23918b11a_m.jpg" width="240" height="132" />
+	</a>
+	<a href="../photos/6841267340_855273fd7e_b.jpg" title="Love">
+		<img alt="Love" src="../photos/6841267340_855273fd7e_m.jpg" width="240" height="137" />
+	</a>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
This CL fixes an issue related to invoking `justifiedGallery('norewind')` on a collection of items where the new items already have their images loaded. This issue only happens when using waitThumbnailsLoad = false.

To fix it I've pulled out the (now) common code used to listen for load events on an image into a new onImageEvent method that both call site now use to register interesting in the image load.
