### PR TITLE
Don't add height of hidden last row to container

### DIFF
--- a/src/js/justifiedGallery.js
+++ b/src/js/justifiedGallery.js
@@ -400,7 +400,7 @@
     var $entry, buildingRowRes, offX = this.border, i;
 
     buildingRowRes = this.prepareBuildingRow(isLastRow);
-    if (isLastRow && settings.lastRow === 'hide' && this.buildingRow.height === -1) {
+    if (isLastRow && settings.lastRow === 'hide' && buildingRowRes === -1) {
       this.clearBuildingRow();
       return;
     }


### PR DESCRIPTION
When lastRow == 'hide' and the last rows items get hidden, the height of the last row was added to the container anyway. This PR fixes this
