### PR TITLE
Added option to justify images in last row to average height

### DIFF
--- a/test/main/lastrow.html
+++ b/test/main/lastrow.html
@@ -63,6 +63,7 @@
             <img src="../photos/6798453217_72dea2d06e_m.jpg" />
         </a>
     </div>
+
     <p>Last row not justified</p>
     <div id="dontjustifylastrow" style="background-color: red;">
         <a href="../photos/8083451788_552becfbc7_b.jpg" title="What's your destination?">
@@ -114,6 +115,7 @@
             <img src="../photos/6798453217_72dea2d06e_m.jpg" />
         </a>
     </div>
+
     <p>Last row aligned left, same as not justified</p>
     <div id="leftlastrow" style="background-color: red;">
         <a href="../photos/8083451788_552becfbc7_b.jpg" title="What's your destination?">
@@ -165,6 +167,7 @@
             <img src="../photos/6798453217_72dea2d06e_m.jpg" />
         </a>
     </div>
+
     <p>Last row centered</p>
     <div id="centeredlastrow" style="background-color: red;">
         <a href="../photos/8083451788_552becfbc7_b.jpg" title="What's your destination?">
@@ -216,6 +219,7 @@
             <img src="../photos/6798453217_72dea2d06e_m.jpg" />
         </a>
     </div>
+
     <p>Last row aligned right</p>
     <div id="rightlastrow" style="background-color: red;">
         <a href="../photos/8083451788_552becfbc7_b.jpg" title="What's your destination?">
@@ -267,6 +271,163 @@
             <img src="../photos/6798453217_72dea2d06e_m.jpg" />
         </a>
     </div>
+
+    <p>Last row aligned left with average height</p>
+    <div id="left-average-lastrow" style="background-color: red;">
+        <a href="../photos/8083451788_552becfbc7_b.jpg" title="What's your destination?">
+            <img src="../photos/8083451788_552becfbc7_m.jpg" />
+        </a>
+        <a href="../photos/7948632554_01f6ae6b6f_b.jpg" title="Just in a dream Place">
+            <img src="../photos/7948632554_01f6ae6b6f_m.jpg" />
+        </a>
+        <a href="../photos/7302459122_19fa1d8223_b.jpg" title="Truthful Innocence">
+            <img src="../photos/7302459122_19fa1d8223_m.jpg" />
+        </a>
+        <a href="../photos/7222046648_5bf70e893a_b.jpg" title="Simply my Brother">
+            <img src="../photos/7222046648_5bf70e893a_m.jpg" />
+        </a>
+        <a href="../photos/7002395006_29fdc85f7a_b.jpg" title="Freedom">
+            <img src="../photos/7002395006_29fdc85f7a_m.jpg" />
+        </a>
+        <a href="../photos/7062575651_b23918b11a_b.jpg" title="Maybe spring">
+            <img src="../photos/7062575651_b23918b11a_m.jpg" />
+        </a>
+        <a href="../photos/6841267340_855273fd7e_b.jpg" title="Love">
+            <img src="../photos/6841267340_855273fd7e_m.jpg" />
+        </a>
+        <a href="../photos/6958456697_e56a37bb5f_b.jpg" title="Young Lovers' Wall and the Old Rain">
+            <img src="../photos/6958456697_e56a37bb5f_m.jpg" />
+        </a>
+        <a href="../photos/6791628438_affaa19e10_b.jpg" title="This is the colors I love">
+            <img src="../photos/6791628438_affaa19e10_m.jpg" />
+        </a>
+        <a href="../photos/6916180091_9c9559e463_b.jpg" title="The Hope">
+            <img src="../photos/6916180091_9c9559e463_m.jpg" />
+        </a>
+        <a href="../photos/6880502467_d4b3c4b2a8_b.jpg" title="Florence streets. Florence people.">
+            <img src="../photos/6880502467_d4b3c4b2a8_m.jpg" />
+        </a>
+        <a href="../photos/6876412479_6268c6e2aa_b.jpg" title="I Love You">
+            <img src="../photos/6876412479_6268c6e2aa_m.jpg" />
+        </a>
+        <a href="../photos/6840627709_92ed52fb41_b.jpg" title="The painter in Florence">
+            <img src="../photos/6840627709_92ed52fb41_m.jpg" />
+        </a>
+        <a href="../photos/6812090617_5fd5bbdda0_b.jpg" title="Me and My Belover">
+            <img src="../photos/6812090617_5fd5bbdda0_m.jpg" />
+        </a>
+        <a href="../photos/6806687375_07d2b7a1f9_b.jpg" title="Fiocco">
+            <img src="../photos/6806687375_07d2b7a1f9_m.jpg" />
+        </a>
+        <a href="../photos/6798453217_72dea2d06e_b.jpg" title="My first clothespin">
+            <img src="../photos/6798453217_72dea2d06e_m.jpg" />
+        </a>
+    </div>
+
+    <p>Last row centered with average height</p>
+    <div id="centered-average-lastrow" style="background-color: red;">
+        <a href="../photos/8083451788_552becfbc7_b.jpg" title="What's your destination?">
+            <img src="../photos/8083451788_552becfbc7_m.jpg" />
+        </a>
+        <a href="../photos/7948632554_01f6ae6b6f_b.jpg" title="Just in a dream Place">
+            <img src="../photos/7948632554_01f6ae6b6f_m.jpg" />
+        </a>
+        <a href="../photos/7302459122_19fa1d8223_b.jpg" title="Truthful Innocence">
+            <img src="../photos/7302459122_19fa1d8223_m.jpg" />
+        </a>
+        <a href="../photos/7222046648_5bf70e893a_b.jpg" title="Simply my Brother">
+            <img src="../photos/7222046648_5bf70e893a_m.jpg" />
+        </a>
+        <a href="../photos/7002395006_29fdc85f7a_b.jpg" title="Freedom">
+            <img src="../photos/7002395006_29fdc85f7a_m.jpg" />
+        </a>
+        <a href="../photos/7062575651_b23918b11a_b.jpg" title="Maybe spring">
+            <img src="../photos/7062575651_b23918b11a_m.jpg" />
+        </a>
+        <a href="../photos/6841267340_855273fd7e_b.jpg" title="Love">
+            <img src="../photos/6841267340_855273fd7e_m.jpg" />
+        </a>
+        <a href="../photos/6958456697_e56a37bb5f_b.jpg" title="Young Lovers' Wall and the Old Rain">
+            <img src="../photos/6958456697_e56a37bb5f_m.jpg" />
+        </a>
+        <a href="../photos/6791628438_affaa19e10_b.jpg" title="This is the colors I love">
+            <img src="../photos/6791628438_affaa19e10_m.jpg" />
+        </a>
+        <a href="../photos/6916180091_9c9559e463_b.jpg" title="The Hope">
+            <img src="../photos/6916180091_9c9559e463_m.jpg" />
+        </a>
+        <a href="../photos/6880502467_d4b3c4b2a8_b.jpg" title="Florence streets. Florence people.">
+            <img src="../photos/6880502467_d4b3c4b2a8_m.jpg" />
+        </a>
+        <a href="../photos/6876412479_6268c6e2aa_b.jpg" title="I Love You">
+            <img src="../photos/6876412479_6268c6e2aa_m.jpg" />
+        </a>
+        <a href="../photos/6840627709_92ed52fb41_b.jpg" title="The painter in Florence">
+            <img src="../photos/6840627709_92ed52fb41_m.jpg" />
+        </a>
+        <a href="../photos/6812090617_5fd5bbdda0_b.jpg" title="Me and My Belover">
+            <img src="../photos/6812090617_5fd5bbdda0_m.jpg" />
+        </a>
+        <a href="../photos/6806687375_07d2b7a1f9_b.jpg" title="Fiocco">
+            <img src="../photos/6806687375_07d2b7a1f9_m.jpg" />
+        </a>
+        <a href="../photos/6798453217_72dea2d06e_b.jpg" title="My first clothespin">
+            <img src="../photos/6798453217_72dea2d06e_m.jpg" />
+        </a>
+    </div>
+
+    <p>Last row aligned right with average height</p>
+    <div id="right-average-lastrow" style="background-color: red;">
+        <a href="../photos/8083451788_552becfbc7_b.jpg" title="What's your destination?">
+            <img src="../photos/8083451788_552becfbc7_m.jpg" />
+        </a>
+        <a href="../photos/7948632554_01f6ae6b6f_b.jpg" title="Just in a dream Place">
+            <img src="../photos/7948632554_01f6ae6b6f_m.jpg" />
+        </a>
+        <a href="../photos/7302459122_19fa1d8223_b.jpg" title="Truthful Innocence">
+            <img src="../photos/7302459122_19fa1d8223_m.jpg" />
+        </a>
+        <a href="../photos/7222046648_5bf70e893a_b.jpg" title="Simply my Brother">
+            <img src="../photos/7222046648_5bf70e893a_m.jpg" />
+        </a>
+        <a href="../photos/7002395006_29fdc85f7a_b.jpg" title="Freedom">
+            <img src="../photos/7002395006_29fdc85f7a_m.jpg" />
+        </a>
+        <a href="../photos/7062575651_b23918b11a_b.jpg" title="Maybe spring">
+            <img src="../photos/7062575651_b23918b11a_m.jpg" />
+        </a>
+        <a href="../photos/6841267340_855273fd7e_b.jpg" title="Love">
+            <img src="../photos/6841267340_855273fd7e_m.jpg" />
+        </a>
+        <a href="../photos/6958456697_e56a37bb5f_b.jpg" title="Young Lovers' Wall and the Old Rain">
+            <img src="../photos/6958456697_e56a37bb5f_m.jpg" />
+        </a>
+        <a href="../photos/6791628438_affaa19e10_b.jpg" title="This is the colors I love">
+            <img src="../photos/6791628438_affaa19e10_m.jpg" />
+        </a>
+        <a href="../photos/6916180091_9c9559e463_b.jpg" title="The Hope">
+            <img src="../photos/6916180091_9c9559e463_m.jpg" />
+        </a>
+        <a href="../photos/6880502467_d4b3c4b2a8_b.jpg" title="Florence streets. Florence people.">
+            <img src="../photos/6880502467_d4b3c4b2a8_m.jpg" />
+        </a>
+        <a href="../photos/6876412479_6268c6e2aa_b.jpg" title="I Love You">
+            <img src="../photos/6876412479_6268c6e2aa_m.jpg" />
+        </a>
+        <a href="../photos/6840627709_92ed52fb41_b.jpg" title="The painter in Florence">
+            <img src="../photos/6840627709_92ed52fb41_m.jpg" />
+        </a>
+        <a href="../photos/6812090617_5fd5bbdda0_b.jpg" title="Me and My Belover">
+            <img src="../photos/6812090617_5fd5bbdda0_m.jpg" />
+        </a>
+        <a href="../photos/6806687375_07d2b7a1f9_b.jpg" title="Fiocco">
+            <img src="../photos/6806687375_07d2b7a1f9_m.jpg" />
+        </a>
+        <a href="../photos/6798453217_72dea2d06e_b.jpg" title="My first clothespin">
+            <img src="../photos/6798453217_72dea2d06e_m.jpg" />
+        </a>
+    </div>
+
     <p>Last row hided</p>
     <div id="hidelastrow" style="background-color: red;">
         <a href="../photos/8083451788_552becfbc7_b.jpg" title="What's your destination?">
@@ -318,13 +479,14 @@
             <img src="../photos/6798453217_72dea2d06e_m.jpg" />
         </a>
     </div>
-    
+
     <!-- bower:js -->
     <script src="../../bower_components/jquery/dist/jquery.js"></script>
     <script src="../../bower_components/colorbox/jquery.colorbox.js"></script>
     <script src="../../bower_components/swipebox/src/js/jquery.swipebox.min.js"></script>
     <script src="../../dist/js/jquery.justifiedGallery.js"></script>
     <!-- endbower -->
+
     <script>
     $("#justifylastrow").justifiedGallery({
         lastRow: 'justify',
@@ -345,6 +507,18 @@
     });
     $("#rightlastrow").justifiedGallery({
         lastRow: 'right',
+        rowHeight: 50
+    });
+    $("#left-average-lastrow").justifiedGallery({
+        lastRow: 'left-average',
+        rowHeight: 50
+    });
+    $("#centered-average-lastrow").justifiedGallery({
+        lastRow: 'center-average',
+        rowHeight: 50
+    });
+    $("#right-average-lastrow").justifiedGallery({
+        lastRow: 'right-average',
         rowHeight: 50
     });
     $("#hidelastrow").justifiedGallery({


### PR DESCRIPTION
Imagine a small portrait screen displaying relative big images, may less
then tree per row. Most of them are required to scale up to fit the area
of the gallery. If the last row is flushed e.g. in nojustify mode (=
default) it gets significant smaller then the others. This looks
annoying, especially on this kind of device. Using justify mode would
fix it in this case, but not acceptable for big screens.

To comply both requirements there are new options (left-average, center-
average and right-average) which cause the last row is resized to the
average row size.

May this become the default instead a new option.
