### PR TITLE
fix issues caused by resizing of gallery when it's not visible

### DIFF
--- a/src/js/justifiedGallery.js
+++ b/src/js/justifiedGallery.js
@@ -453,6 +453,9 @@
   var scrollBarOn = false;
   JustifiedGallery.prototype.checkWidth = function () {
     this.checkWidthIntervalId = setInterval($.proxy(function () {
+      // if the gallery is not currently visible, abort.
+      if (!this.$gallery.is(":visible"))
+        return;
       var galleryWidth = parseFloat(this.$gallery.width());
       if (hasScrollBar() === scrollBarOn) {
         if (Math.abs(galleryWidth - this.galleryWidth) > this.settings.refreshSensitivity) {


### PR DESCRIPTION
Hi 

I've noticed some issues caused if you end up hiding the justified gallery and then showing it again. The problem relates to the width of the gallery changing (potentially to 0px) when the gallery is hidden. As a result when it's shown again it doesn't refresh properly unless you resize the browser window. The attached simple fixed simple skips the gallery resize checking if the gallery isn't currently visible - I guess this is a useful performance hack anyway since there shouldn't be any need to be checking whether to resize the gallery or not if it's not visible. If resizing needs to be done then the code will do its job as soon as the gallery becomes visible.

Never used grunt before but if you're will to pull this I can look in to compiling the change in to the dist/ js files also.

Hope this helps!