### PR TITLE
[Security] Prevent XSS attack in captions

### DIFF
--- a/src/js/justifiedGallery.js
+++ b/src/js/justifiedGallery.js
@@ -236,7 +236,7 @@ JustifiedGallery.prototype.displayEntryCaption = function ($entry) {
       var caption = $image.attr('alt');
       if (!this.isValidCaption(caption)) caption = $entry.attr('title');
       if (this.isValidCaption(caption)) { // Create only we found something
-        $imgCaption = $('<div class="jg-caption">' + caption + '</div>');
+        $imgCaption = $('<div class="jg-caption"></div>').text(caption);
         $entry.append($imgCaption);
         $entry.data('jg.createdCaption', true);
       }


### PR DESCRIPTION
We're using Justified Gallery over at [Friendica](https://github.com/friendica/friendica) and we've been reported a security vulnerability related to this Javascript library. Image captions, even correctly escaped in the source page HTML, end up being interpreted as literal HTML in the Justified Gallery output.

This is because jQuery `$('<div>' + caption + '</div>')` treats `caption` as literal HTML. However, this value comes from HTML attributes that shouldn't contain literal HTML themselves.

The fix is simple and ensures jQuery uses the `.createTextNode()` DOM method internally, which escapes literal HTML in the output HTML tag.

I have checked for any other place the replaced structure would make sense.