### PR TITLE
fixes #389

### DIFF
--- a/src/js/justifiedGallery.js
+++ b/src/js/justifiedGallery.js
@@ -194,7 +194,7 @@ JustifiedGallery.prototype.displayEntry = function ($entry, x, y, imgWidth, imgH
 
       $image.one('error', function () {
          this.resetImgSrc($image); //revert to the original thumbnail
-      });
+      }.bind(this));
 
       var loadNewImage = function () {
         // if (imageSrc !== newImageSrc) { 


### PR DESCRIPTION
Upon troubleshooting, it was found that when an image throws an error, this inside the callback refers to the image element and not the JustifiedGallery instance. This causes a TypeError because this.resetImgSrc is not a function in the context of the image element.

To resolve this, I ensured that this correctly refers to the JustifiedGallery instance by using .bind(this) on the callback function.

Also might help resolve: https://github.com/miromannino/Justified-Gallery/issues/333, https://github.com/miromannino/Justified-Gallery/issues/351